### PR TITLE
Force 4 Bytes to enum types

### DIFF
--- a/src/main/resources/com/eprosima/uxr/idl/templates/TypesHeader.stg
+++ b/src/main/resources/com/eprosima/uxr/idl/templates/TypesHeader.stg
@@ -96,6 +96,8 @@ typedef enum $enum.name$
 {
     $enum.members:{$it.name$}; separator=",\n"$
 } $enum.name$;
+
+typedef uint32_t $enum.name$_cdr;
 >>
 
 /***** Utils *****/
@@ -119,6 +121,8 @@ $member.typecode.contentTypeCode.cTypename$ $member.name$;
 $endif$
 $elseif(member.typecode.isType_f)$
 $member.typecode.cTypename$ $member.name$$member.typecode.cTypeDimensions$;
+$elseif(member.typecode.isType_c)$
+$member.typecode.cTypename$_cdr $member.name$;
 $else$
 $member.typecode.cTypename$ $member.name$;
 $endif$


### PR DESCRIPTION
This PR address https://github.com/eProsima/Micro-XRCE-DDS-Gen/issues/67

In general, it creates an intermediate typedef that forces the Enum types to be a `uint32_t` in the generated struct.

This way, the enum definition can be less than 4 B (due to short-enums) but the representation will be CDR compliant. Also the assignation shall be warning-less.